### PR TITLE
Remove the renewal lines in terraform output

### DIFF
--- a/terraform_filter.py
+++ b/terraform_filter.py
@@ -8,7 +8,20 @@ import sys
 import re
 
 def filter_terraform_output(tf_output, keys):
+    renewal_string = "------------------------------------------------------------------------"
+
     output = tf_output
+
+    r_index = output.find(renewal_string)
+    # remove everything above and including the renewal string
+    # this also removes the newline
+    output = output[r_index + len(renewal_string) + 2:]
+
+    r_index = output.rfind(renewal_string)
+    # remove everything after and including the final renewal string
+    # this also removes the newline
+    output = output[:r_index - 2]
+    
     for key in keys:
         reg = r"%s.*" % key
         matches = re.finditer(reg, output, re.IGNORECASE)


### PR DESCRIPTION
Terraform output places the changes it will be making between two
lines that look like:

```
---------------------------------------------------------------------

< ... important changes here ...>

---------------------------------------------------------------------
```

Everything outside of these lines is related to renewing modules and
other terraform-specific stuff. These updates are not important for
PRs and the changes will be noted within the `renewal` lines
anyways. I will filter these lines out so the change sets are easier
to read and digest.